### PR TITLE
Preview financing documents (Backend)

### DIFF
--- a/lib/hancock/envelope.rb
+++ b/lib/hancock/envelope.rb
@@ -288,14 +288,6 @@ module Hancock
 
     def recipient_validity
       check_collection_validity(:recipients, Recipient)
-
-      unless has_unique_emails?
-        errors.add(:recipients, 'must all have unique emails')
-      end
-    end
-
-    def has_unique_emails?
-      recipients.map { |r| r.try(:email) }.uniq.length == recipients.length
     end
 
     def document_validity

--- a/lib/hancock/envelope.rb
+++ b/lib/hancock/envelope.rb
@@ -287,12 +287,5 @@ module Hancock
     def document_validity
       check_collection_validity(:documents, Document)
     end
-
-    #
-    # format recipient type(symbol) for DocuSign
-    #
-    def docusign_recipient_type(type)
-      type.to_s.camelize(:lower).pluralize
-    end
   end
 end

--- a/lib/hancock/envelope.rb
+++ b/lib/hancock/envelope.rb
@@ -47,6 +47,8 @@ module Hancock
       @recipients << recipient unless @recipients.include? recipient
       @documents << document unless @documents.include? document
 
+      return if recipient.recipient_type == :carbon_copy && recipient.client_user_id.present?
+
       @signature_requests << {
         :recipient => recipient,
         :document => document,
@@ -132,6 +134,18 @@ module Hancock
     end
 
     private
+
+    # CarbonCopy recipients who have a clientUserId cannot be added at creation
+    # unlike most other recipients. 
+    def embedded_carbon_copy_recipients
+      recipients.select do |recipient| 
+        recipient.recipient_type == :carbon_copy && recipient.client_user_id.present?
+      end
+    end
+
+    def normal_recipients
+      recipients - embedded_carbon_copy_recipients
+    end
 
     def docusign_envelope
       @docusign_envelope ||= DocusignEnvelope.new(self)

--- a/lib/hancock/envelope.rb
+++ b/lib/hancock/envelope.rb
@@ -31,20 +31,26 @@ module Hancock
       @status = attributes[:status]
       @documents = attributes[:documents] || []
       @recipients = attributes[:recipients] || []
-      @signature_requests = attributes[:signature_requests] || []
       @email = attributes[:email] || {}
       @reminder = attributes[:reminder]
       @expiration = attributes[:expiration]
+
+      @signature_requests = []
+      if attributes[:signature_requests]
+        attributes[:signature_requests].map do |signature_request|  
+          add_signature_request(signature_request)
+        end
+      end
     end
 
-    def add_signature_request(attributes = {})
-      @recipients << attributes[:recipient] unless @recipients.include? attributes[:recipient]
-      @documents << attributes[:document] unless @documents.include? attributes[:document]
+    def add_signature_request(recipient: , document: nil, tabs: nil)
+      @recipients << recipient unless @recipients.include? recipient
+      @documents << document unless @documents.include? document
 
       @signature_requests << {
-        :recipient => attributes[:recipient],
-        :document => attributes[:document],
-        :tabs => attributes[:tabs]
+        :recipient => recipient,
+        :document => document,
+        :tabs => tabs
       }
     end
 

--- a/lib/hancock/envelope.rb
+++ b/lib/hancock/envelope.rb
@@ -37,7 +37,7 @@ module Hancock
 
       @signature_requests = []
       if attributes[:signature_requests]
-        attributes[:signature_requests].map do |signature_request|  
+        attributes[:signature_requests].map do |signature_request|
           add_signature_request(signature_request)
         end
       end
@@ -117,6 +117,11 @@ module Hancock
       self
     end
 
+    def current_routing_order
+      Recipient::DocusignRecipient.all_for(identifier)
+        .parsed_response['currentRoutingOrder'].to_i
+    end
+
     def notification_for_params
       {
         :useAccountDefaults => false,
@@ -136,9 +141,9 @@ module Hancock
     private
 
     # CarbonCopy recipients who have a clientUserId cannot be added at creation
-    # unlike most other recipients. 
+    # unlike most other recipients.
     def embedded_carbon_copy_recipients
-      recipients.select do |recipient| 
+      recipients.select do |recipient|
         recipient.recipient_type == :carbon_copy && recipient.client_user_id.present?
       end
     end

--- a/lib/hancock/recipient.rb
+++ b/lib/hancock/recipient.rb
@@ -52,10 +52,19 @@ module Hancock
       end.flatten
     end
 
-    # DocuSign currently provides no way to resend an envelope for a
-    # recipient with embedded signing enabled. So we use a workaround.
     def resend_email
-      recreate_recipient_and_tabs
+      if access_method == :remote
+        # The API seems to require more than just recipientId
+        docusign_recipient.update(
+          :recipientId => identifier,
+          :name => name,
+          :resend_envelope => true
+        )
+      elsif access_method == :embedded
+        # DocuSign currently provides no way to resend an envelope for a
+        # recipient with embedded signing enabled. So we use a workaround.
+        recreate_recipient_and_tabs
+      end
     end
 
     # The DocuSign API provides no way to change the access method for an

--- a/lib/hancock/recipient.rb
+++ b/lib/hancock/recipient.rb
@@ -7,15 +7,15 @@ module Hancock
 
     TYPES = [:agent, :carbon_copy, :certified_delivery, :editor, :in_person_signer, :intermediary, :signer]
 
-    attr_accessor :email,
+    attr_accessor :client_user_id,
+      :email,
       :id_check,
       :identifier,
       :name,
       :recipient_type,
       :routing_order
 
-    attr_reader :client_user_id,
-      :envelope_identifier,
+    attr_reader :envelope_identifier,
       :docusign_recipient,
       :embedded_start_url
 
@@ -84,6 +84,11 @@ module Hancock
       end
 
       docusign_recipient.signing_url(return_url).parsed_response['url']
+    end
+
+    def create(envelope_identifier: )
+      @envelope_identifier = envelope_identifier
+      docusign_recipient.create
     end
 
     def to_hash

--- a/lib/hancock/recipient.rb
+++ b/lib/hancock/recipient.rb
@@ -37,10 +37,19 @@ module Hancock
     end
 
     def self.fetch_for_envelope(envelope_identifier)
-      response = DocusignRecipient.all_for(envelope_identifier).parsed_response
+      parsed_response = DocusignRecipient.all_for(envelope_identifier).parsed_response
+      recipients_from(envelope_identifier, parsed_response)
+    end
 
+    def self.at_current_routing_order_for(envelope_identifier)
+      parsed_response = DocusignRecipient.all_for(envelope_identifier).parsed_response
+      recipients_from(envelope_identifier, parsed_response)
+        .select {|r| r.routing_order == parsed_response['currentRoutingOrder'].to_i }
+    end
+
+    def self.recipients_from(envelope_identifier, parsed_response)
       TYPES.map do |type|
-        response[docusign_recipient_type(type)].map do |envelope_recipient|
+        parsed_response[docusign_recipient_type(type)].map do |envelope_recipient|
           new(:name => envelope_recipient['name'],
               :email => envelope_recipient['email'],
               :id_check => nil,

--- a/lib/hancock/recipient.rb
+++ b/lib/hancock/recipient.rb
@@ -99,6 +99,16 @@ module Hancock
       }
     end
 
+    #
+    # format recipient_type(symbol) for DocuSign
+    #
+    def self.docusign_recipient_type(recipient_type)
+      DocusignRecipient.docusign_recipient_type(recipient_type)
+    end
+    def docusign_recipient_type
+      DocusignRecipient.docusign_recipient_type(recipient_type)
+    end
+
     private
 
     def recreate_recipient_and_tabs
@@ -115,13 +125,6 @@ module Hancock
 
     def access_method
       client_user_id.nil? ? :remote : :embedded
-    end
-
-    #
-    # format recipient type(symbol) for DocuSign
-    #
-    def self.docusign_recipient_type(type)
-      type.to_s.camelize(:lower).pluralize
     end
   end
 end

--- a/lib/hancock/recipient.rb
+++ b/lib/hancock/recipient.rb
@@ -38,25 +38,19 @@ module Hancock
 
     def self.fetch_for_envelope(envelope_identifier)
       parsed_response = DocusignRecipient.all_for(envelope_identifier).parsed_response
-      recipients_from(envelope_identifier, parsed_response)
-    end
 
-    def self.at_current_routing_order_for(envelope_identifier)
-      parsed_response = DocusignRecipient.all_for(envelope_identifier).parsed_response
-      recipients_from(envelope_identifier, parsed_response)
-        .select {|r| r.routing_order == parsed_response['currentRoutingOrder'].to_i }
-    end
-
-    def self.recipients_from(envelope_identifier, parsed_response)
       TYPES.map do |type|
         parsed_response[docusign_recipient_type(type)].map do |envelope_recipient|
-          new(:name => envelope_recipient['name'],
-              :email => envelope_recipient['email'],
-              :id_check => nil,
-              :routing_order => envelope_recipient['routingOrder'].to_i,
-              :recipient_type => type,
-              :identifier => envelope_recipient['recipientId'].to_i,
-              :envelope_identifier => envelope_identifier)
+          new(
+            :client_user_id => envelope_recipient['clientUserId'],
+            :email => envelope_recipient['email'],
+            :envelope_identifier => envelope_identifier,
+            :id_check => nil,
+            :identifier => envelope_recipient['recipientId'].to_i,
+            :name => envelope_recipient['name'],
+            :routing_order => envelope_recipient['routingOrder'].to_i,
+            :recipient_type => type
+          )
         end
       end.flatten
     end
@@ -94,9 +88,6 @@ module Hancock
     end
 
     def signing_url(return_url)
-      # FIXME: We need to check the status somehow
-      # fail unless status == :sent
-
       unless access_method == :embedded
         fail SigningUrlError, 'This recipient is not setup for in-person signing'
       end

--- a/lib/hancock/recipient/docusign_recipient.rb
+++ b/lib/hancock/recipient/docusign_recipient.rb
@@ -57,10 +57,16 @@ module Hancock
         )
       end
 
-      def update
+      def update(resend_envelope: false, **attrs)
+        unless [true, false].include? resend_envelope
+          raise ArgumentError.new('resend_envelope must be either true or false')
+        end
+
+        data_to_update = attrs.present? ? attrs : to_hash
+
         Hancock::Request.send_put_request(
-          "/envelopes/#{envelope_identifier}/recipients",
-          { :signers => [to_hash] }.to_json
+          "/envelopes/#{envelope_identifier}/recipients?resend_envelope=#{resend_envelope}",
+          { :signers => [data_to_update] }.to_json
         )
       end
 

--- a/lib/hancock/recipient/docusign_recipient.rb
+++ b/lib/hancock/recipient/docusign_recipient.rb
@@ -4,7 +4,11 @@ module Hancock
       attr_reader :recipient
 
       extend Forwardable
-      def_delegators :@recipient, :envelope_identifier, :identifier, :to_hash
+      def_delegators :@recipient, 
+        :envelope_identifier, 
+        :identifier,
+        :recipient_type,
+        :to_hash
 
       def initialize(recipient)
         fail 'recipient requires an envelope_identifier' unless recipient.envelope_identifier
@@ -47,7 +51,7 @@ module Hancock
       def create
         Hancock::Request.send_post_request(
           "/envelopes/#{envelope_identifier}/recipients",
-          { :signers => [to_hash] }.to_json
+          { docusign_recipient_type => [to_hash] }.to_json
         )
       end
 

--- a/lib/hancock/recipient/docusign_recipient.rb
+++ b/lib/hancock/recipient/docusign_recipient.rb
@@ -24,11 +24,6 @@ module Hancock
           "/envelopes/#{envelope_identifier}/recipients")
       end
 
-      def self.find(envelope_identifier, identifier)
-        Hancock::Request.send_get_request(
-          "/envelopes/#{envelope_identifier}/recipients/#{identifier}")
-      end
-
       def tabs
         Hancock::Request.send_get_request(
           "/envelopes/#{envelope_identifier}/recipients/#{identifier}/tabs")

--- a/lib/hancock/recipient/docusign_recipient.rb
+++ b/lib/hancock/recipient/docusign_recipient.rb
@@ -71,6 +71,16 @@ module Hancock
           json_body
         )
       end
+
+      #
+      # format recipient type(symbol) for DocuSign
+      #
+      def self.docusign_recipient_type(recipient_type)
+        recipient_type.to_s.camelize(:lower).pluralize
+      end
+      def docusign_recipient_type
+        recipient_type.to_s.camelize(:lower).pluralize
+      end
     end
   end
 end

--- a/lib/hancock/recipient/docusign_recipient.rb
+++ b/lib/hancock/recipient/docusign_recipient.rb
@@ -4,10 +4,12 @@ module Hancock
       attr_reader :recipient
 
       extend Forwardable
-      def_delegators :@recipient, 
-        :envelope_identifier, 
+
+      def_delegators :@recipient,
+        :envelope_identifier,
         :identifier,
         :recipient_type,
+        :routing_order,
         :to_hash
 
       def initialize(recipient)

--- a/lib/hancock/recipient/recreator.rb
+++ b/lib/hancock/recipient/recreator.rb
@@ -32,11 +32,12 @@ module Hancock
       def placeholder_recipient
         Recipient.new(
           :client_user_id      => placeholder_identifier, # Don't send an email
-          :email               => 'placeholder@example.com',
-          :envelope_identifier => docusign_recipient.envelope_identifier,
           :identifier          => placeholder_identifier,
+          :email               => 'placeholder@example.com',
           :name                => 'Placeholder while recreating recipient',
-          :recipient_type      => :signer,
+          :envelope_identifier => docusign_recipient.envelope_identifier,
+          :recipient_type      => docusign_recipient.recipient_type,
+          :routing_order       => docusign_recipient.routing_order,
           :embedded_start_url  => nil # No really, don't send an email
         )
       end

--- a/lib/hancock/version.rb
+++ b/lib/hancock/version.rb
@@ -1,3 +1,3 @@
 module Hancock
-  VERSION = '0.3.0'
+  VERSION = '0.4.0'
 end

--- a/spec/fixtures/request_bodies/send_envelope.txt
+++ b/spec/fixtures/request_bodies/send_envelope.txt
@@ -2,7 +2,7 @@
 Content-Type: application/json
 Content-Disposition: form-data
 
-{"emailBlurb":"flurb","emailSubject":"fubject","status":"","documents":"the_documents","recipients":"the_requests","notification":{"useAccountDefaults":false,"reminders":{"reminderEnabled":false},"expirations":{"expireEnabled":false}}}
+{"emailBlurb":"flurb","emailSubject":"fubject","status":"sent","documents":"the_documents","recipients":"the_requests","notification":{"useAccountDefaults":false,"reminders":{"reminderEnabled":false},"expirations":{"expireEnabled":false}}}
 --MYBOUNDARY
 hello world
 --MYBOUNDARY--

--- a/spec/lib/envelope/docusign_envelope_spec.rb
+++ b/spec/lib/envelope/docusign_envelope_spec.rb
@@ -19,11 +19,4 @@ describe Hancock::Envelope::DocusignEnvelope do
       subject.viewing_url
     end
   end
-
-  describe '#send_envelope' do
-    xit 'sets the status of each signer to "sent"' do
-      # PUT v2/accounts/:accountId/envelopes/:envelopeId
-      # { "status": "sent" }
-    end
-  end
 end

--- a/spec/lib/envelope_spec.rb
+++ b/spec/lib/envelope_spec.rb
@@ -457,6 +457,21 @@ describe Hancock::Envelope do
       end
     end
 
+    describe '#current_routing_order' do
+      subject { described_class.new(:identifier => 'smokey-joe') }
+
+      it 'uses DocusignRecipient because that\'s what the API requires :(' do
+        stub_request(:get, 'https://demo.docusign.net/restapi/v2/accounts/123456/envelopes/smokey-joe/recipients').
+          to_return(
+            :status => 200,
+            :body => '{"currentRoutingOrder":"7","other":"stuff"}',
+            :headers => {'Content-Type' => 'application/json'}
+          )
+
+        expect(subject.current_routing_order).to eq(7)
+      end
+    end
+
     describe '#signature_requests_for_params' do
       let(:document1) { Hancock::Document.new(:identifier => 1) }
       let(:document2) { Hancock::Document.new(:identifier => 2) }

--- a/spec/lib/envelope_spec.rb
+++ b/spec/lib/envelope_spec.rb
@@ -23,15 +23,6 @@ describe Hancock::Envelope do
     it { is_expected.not_to have_valid(:recipients).when([], nil, [:not_a_recipient], [association(Hancock::Recipient, :validity => false)]) }
     it { is_expected.to have_valid(:documents).when([association(Hancock::Document)]) }
     it { is_expected.not_to have_valid(:documents).when([], nil, [:not_a_document], [association(Hancock::Document, :validity => false)]) }
-
-    context 'recipients' do
-      it 'validates uniqueness of emails' do
-        subject.recipients = [recipient, recipient]
-        subject.valid?
-
-        expect(subject.errors[:recipients]).to include("must all have unique emails")
-      end
-    end
   end
 
   context 'with valid envelope' do
@@ -244,7 +235,7 @@ describe Hancock::Envelope do
         it 'adds regular carbon-copy recipients in the first post' do
           recipient2.recipient_type = :carbon_copy
           subject.add_signature_request({ :recipient => recipient2, :document => document1, :tabs => [tab1] })
-          
+
           expect(Hancock::Request)
             .to receive(:send_post_request)
             .with('/envelopes', /.*carbonCopies.*/, anything)
@@ -411,7 +402,7 @@ describe Hancock::Envelope do
       end
 
       it 'adds regular carbon_copy recipients to the list of signature requests' do
-        recipient = instance_double(Hancock::Recipient, 
+        recipient = instance_double(Hancock::Recipient,
           :recipient_type => :carbon_copy,
           :client_user_id => nil)
         attributes = {
@@ -427,7 +418,7 @@ describe Hancock::Envelope do
       end
 
       it 'does not add embedded carbon_copy recipients to the list of signature requests' do
-        recipient = instance_double(Hancock::Recipient, 
+        recipient = instance_double(Hancock::Recipient,
           :recipient_type => :carbon_copy,
           :client_user_id => 123)
         attributes = {
@@ -448,8 +439,8 @@ describe Hancock::Envelope do
         envelope = Hancock::Envelope.new({
           documents: [:document],
           signature_requests: [{
-            :recipient => recipient, 
-            :document => :document, 
+            :recipient => recipient,
+            :document => :document,
             :tabs => [:tabs]}],
           email: {
             subject: 'Hello there',

--- a/spec/lib/envelope_spec.rb
+++ b/spec/lib/envelope_spec.rb
@@ -25,7 +25,7 @@ describe Hancock::Envelope do
     it { is_expected.not_to have_valid(:documents).when([], nil, [:not_a_document], [association(Hancock::Document, :validity => false)]) }
 
     context 'recipients' do
-      it "validates uniqueness of emails" do
+      it 'validates uniqueness of emails' do
         subject.recipients = [recipient, recipient]
         subject.valid?
 
@@ -124,7 +124,7 @@ describe Hancock::Envelope do
         allow(subject).to receive(:email).and_return({ :subject => 'fubject', :blurb => 'flurb'})
       end
 
-      it 'should raise exception if envelope is not valid' do
+      it 'raises an exception if envelope is not valid' do
         allow(subject).to receive(:valid?).and_return(false)
         allow(subject).to receive_message_chain(:errors, :full_messages).and_return(
           ['rice pudding', 'wheat berries']
@@ -135,7 +135,7 @@ describe Hancock::Envelope do
         )
       end
 
-      it 'should raise exception if Hancock not configured' do
+      it 'raises an exception if Hancock not configured' do
         allow(Hancock).to receive(:configured?).and_return(false)
         expect {
           subject.send!

--- a/spec/lib/envelope_spec.rb
+++ b/spec/lib/envelope_spec.rb
@@ -130,7 +130,7 @@ describe Hancock::Envelope do
           ['rice pudding', 'wheat berries']
         )
 
-        expect { subject.send_envelope }.to raise_error(
+        expect { subject.send! }.to raise_error(
           described_class::InvalidEnvelopeError, 'rice pudding; wheat berries'
         )
       end
@@ -138,7 +138,7 @@ describe Hancock::Envelope do
       it 'should raise exception if Hancock not configured' do
         allow(Hancock).to receive(:configured?).and_return(false)
         expect {
-          subject.send_envelope
+          subject.send!
         }.to raise_error(Hancock::ConfigurationMissing)
       end
 
@@ -151,7 +151,7 @@ describe Hancock::Envelope do
         end
 
         it "should add unique positive integer ids on sending" do
-          subject.send_envelope
+          subject.send!
 
           expect(subject.documents.map(&:identifier).all?{|x| x.integer? && x > 0}).to be_truthy
           expect(subject.documents.map(&:identifier).uniq.length).to eq(subject.documents.length)
@@ -161,7 +161,7 @@ describe Hancock::Envelope do
           subject.documents[0].identifier = 3
           subject.documents[1].identifier = 4
 
-          subject.send_envelope
+          subject.send!
 
           expect(subject.documents.map(&:identifier)).to eq([3,4])
         end
@@ -169,7 +169,7 @@ describe Hancock::Envelope do
         it "should preserve existing ids and generate missing ones" do
           subject.documents[1].identifier = 6
 
-          subject.send_envelope
+          subject.send!
 
           expect(subject.documents.map(&:identifier)).to eq([7,6])
         end
@@ -184,7 +184,7 @@ describe Hancock::Envelope do
         end
 
         it "should add unique positive integer ids on sending" do
-          subject.send_envelope
+          subject.send!
 
           expect(subject.recipients.map(&:identifier).all?{|x| x.integer? && x > 0}).to be_truthy
           expect(subject.recipients.map(&:identifier).uniq.length).to eq(subject.recipients.length)
@@ -194,7 +194,7 @@ describe Hancock::Envelope do
           subject.recipients[0].identifier = 3
           subject.recipients[1].identifier = 4
 
-          subject.send_envelope
+          subject.send!
 
           expect(subject.recipients.map(&:identifier)).to eq([3,4])
         end
@@ -202,7 +202,7 @@ describe Hancock::Envelope do
         it "should preserve existing ids and generate missing ones" do
           subject.recipients[1].identifier = 6
 
-          subject.send_envelope
+          subject.send!
 
           expect(subject.recipients.map(&:identifier)).to eq([7,6])
         end
@@ -215,17 +215,17 @@ describe Hancock::Envelope do
         end
 
         it "sends envelope with given status" do
-          subject.send_envelope
+          subject.send!
           expect(request_stub).to have_been_requested
         end
 
         it 'calls #reload!' do
           expect(subject).to receive(:reload!)
-          subject.send_envelope
+          subject.send!
         end
 
         it 'sets the identifier to whatever DocuSign returned' do
-          subject.send_envelope
+          subject.send!
           expect(subject.identifier).to eq 'a-crazy-envelope-id'
         end
       end
@@ -235,7 +235,7 @@ describe Hancock::Envelope do
 
         it 'raises a DocusignError with the returned message if not successful' do
           expect {
-            subject.send_envelope
+            subject.send!
           }.to raise_error(Hancock::Request::RequestError, '500 - YOU_ARE_A_BANANA - Bananas are not allowed to bank.')
         end
       end
@@ -352,7 +352,7 @@ describe Hancock::Envelope do
             { :recipient => recipient2, :document => document2, :tabs => [tab1] }
           ]
         })
-        expect(subject.signature_requests_for_params).to match({
+        expect(subject.send(:signature_requests_for_params)).to match({
           'signers' => [
             {
               :clientUserId => nil,
@@ -403,12 +403,12 @@ describe Hancock::Envelope do
         }
 
         it 'sets requireIdLookup to false' do
-          expect(subject.signature_requests_for_params['signers']
+          expect(subject.send(:signature_requests_for_params)['signers']
             .first[:requireIdLookup]).to be(false)
         end
 
         it 'does not include idCheckConfigurationName' do
-          expect(subject.signature_requests_for_params['signers']
+          expect(subject.send(:signature_requests_for_params)['signers']
             .first[:idCheckConfigurationName]).to be_nil
         end
       end

--- a/spec/lib/recipient/docusign_recipient_spec.rb
+++ b/spec/lib/recipient/docusign_recipient_spec.rb
@@ -139,11 +139,41 @@ describe Hancock::Recipient::DocusignRecipient do
       }.to_json
     }
 
-    it 'makes a request' do
+    it 'sets "resend_envelope" to false by default' do
       expect(Hancock::Request).to receive(:send_put_request)
-        .with('/envelopes/amelia-badelia/recipients', expected_json)
+        .with('/envelopes/amelia-badelia/recipients?resend_envelope=false', expected_json)
 
       subject.update
+    end
+
+    it 'allows "resend_envelope" to be specified' do
+      expect(Hancock::Request).to receive(:send_put_request)
+        .with('/envelopes/amelia-badelia/recipients?resend_envelope=true', expected_json)
+
+      subject.update(:resend_envelope => true)
+    end
+
+    it 'raises an Exception if "resend_envelope" is not true or false' do
+      expect{ subject.update(:resend_envelope => 'jibburrish') }.to raise_error
+    end
+
+    it 'defaults to updating all values from `to_hash`' do
+      allow(recipient).to receive(:to_hash).and_return({ :humpty => 'dumpty' })
+      expected_json = { :signers => [{ :humpty => 'dumpty' }] }.to_json
+
+      expect(Hancock::Request).to receive(:send_put_request)
+        .with('/envelopes/amelia-badelia/recipients?resend_envelope=false', expected_json)
+
+      subject.update
+    end
+
+    it 'defaults to updating all values from `to_hash`' do
+      expected_json = { :signers => [{ :cheshire => 'cat' }] }.to_json
+
+      expect(Hancock::Request).to receive(:send_put_request)
+        .with('/envelopes/amelia-badelia/recipients?resend_envelope=false', expected_json)
+
+      subject.update(:cheshire => 'cat')
     end
   end
 end

--- a/spec/lib/recipient/docusign_recipient_spec.rb
+++ b/spec/lib/recipient/docusign_recipient_spec.rb
@@ -38,15 +38,6 @@ describe Hancock::Recipient::DocusignRecipient do
     end
   end
 
-  describe '.find' do
-    it 'makes a request' do
-      expect(Hancock::Request).to receive(:send_get_request)
-        .with('/envelopes/yosemite-sam/recipients/bugs-bunny')
-
-      described_class.find('yosemite-sam', 'bugs-bunny')
-    end
-  end
-
   describe '#signing_url' do
     it 'makes a request to Docusign' do
       expected_json = {

--- a/spec/lib/recipient/recreator_spec.rb
+++ b/spec/lib/recipient/recreator_spec.rb
@@ -12,7 +12,8 @@ describe Hancock::Recipient::Recreator do
         :identifier          => '7890',
         :name                => 'Fred Flinstone',
         :recipient_type      => :signer,
-        :embedded_start_url  => 'SIGN_AT_DOCUSIGN'
+        :embedded_start_url  => 'place to start!',
+        :routing_order       => 2_000
       )
     }
     let(:docusign_recipient) { recipient.send(:docusign_recipient) }
@@ -31,8 +32,7 @@ describe Hancock::Recipient::Recreator do
 
       expect(WebMock).to have_requested(:post, "https://demo.docusign.net/restapi/v2/accounts/123456/envelopes/1234-5678-9012/recipients")
         .with(
-          :body => "{\"signers\":[{\"clientUserId\":\"123-placeholder-id\",\"email\":\"placeholder@example.com\",\"name\":\"Placeholder while recreating recipient\",\"recipientId\":\"123-placeholder-id\",\"routingOrder\":1,\"requireIdLookup\":true,\"idCheckConfigurationName\":\"ID Check $\",\"embeddedRecipientStartURL\":null}]}",
-          :headers => {'Accept'=>'application/json', 'Authorization'=>'bearer', 'Content-Type'=>'application/json'}
+          :body => "{\"signers\":[{\"clientUserId\":\"123-placeholder-id\",\"email\":\"placeholder@example.com\",\"name\":\"Placeholder while recreating recipient\",\"recipientId\":\"123-placeholder-id\",\"routingOrder\":2000,\"requireIdLookup\":true,\"idCheckConfigurationName\":\"ID Check $\",\"embeddedRecipientStartURL\":null}]}"
         )
     end
 
@@ -40,9 +40,7 @@ describe Hancock::Recipient::Recreator do
       subject.recreate_with_tabs
 
       expect(WebMock).to have_requested(:delete, "https://demo.docusign.net/restapi/v2/accounts/123456/envelopes/1234-5678-9012/recipients")
-        .with(
-          :body => "{\"signers\":[{\"recipientId\":\"7890\"}]}",
-          :headers => {'Accept'=>'application/json', 'Authorization'=>'bearer', 'Content-Type'=>'application/json'})
+        .with(:body => "{\"signers\":[{\"recipientId\":\"7890\"}]}")
     end
 
     it 'recreates the recipient' do
@@ -50,17 +48,15 @@ describe Hancock::Recipient::Recreator do
 
       expect(WebMock).to have_requested(:post, "https://demo.docusign.net/restapi/v2/accounts/123456/envelopes/1234-5678-9012/recipients")
         .with(
-          :body => "{\"signers\":[{\"clientUserId\":\"7890\",\"email\":\"actual_recipient@example.com\",\"name\":\"Fred Flinstone\",\"recipientId\":\"7890\",\"routingOrder\":1,\"requireIdLookup\":true,\"idCheckConfigurationName\":\"ID Check $\",\"embeddedRecipientStartURL\":\"SIGN_AT_DOCUSIGN\"}]}",
-          :headers => {'Accept'=>'application/json', 'Authorization'=>'bearer', 'Content-Type'=>'application/json'})
+          :body => "{\"signers\":[{\"clientUserId\":\"7890\",\"email\":\"actual_recipient@example.com\",\"name\":\"Fred Flinstone\",\"recipientId\":\"7890\",\"routingOrder\":2000,\"requireIdLookup\":true,\"idCheckConfigurationName\":\"ID Check $\",\"embeddedRecipientStartURL\":\"place to start!\"}]}"
+        )
     end
 
     it 'recreates tabs for the recipient if there were any' do
       subject.recreate_with_tabs
 
       expect(WebMock).to have_requested(:post, "https://demo.docusign.net/restapi/v2/accounts/123456/envelopes/1234-5678-9012/recipients/7890/tabs")
-        .with(
-          :body => "{\"rainbows\":\"butterflies\"}",
-          :headers => {'Accept'=>'application/json', 'Authorization'=>'bearer', 'Content-Type'=>'application/json'})
+        .with(:body => "{\"rainbows\":\"butterflies\"}")
     end
 
     it 'does not recreate tabs if there were originally none' do
@@ -76,8 +72,7 @@ describe Hancock::Recipient::Recreator do
 
       expect(WebMock).to have_requested(:delete, "https://demo.docusign.net/restapi/v2/accounts/123456/envelopes/1234-5678-9012/recipients")
         .with(
-          :body => "{\"signers\":[{\"recipientId\":\"123-placeholder-id\"}]}",
-          :headers => {'Accept'=>'application/json', 'Authorization'=>'bearer', 'Content-Type'=>'application/json'})
+          :body => "{\"signers\":[{\"recipientId\":\"123-placeholder-id\"}]}")
     end
   end
 end

--- a/spec/lib/recipient_spec.rb
+++ b/spec/lib/recipient_spec.rb
@@ -101,14 +101,38 @@ describe Hancock::Recipient do
       )
     }
 
-    it 'recreates the recipient' do
-      recreator = double(Hancock::Recipient::Recreator)
+    context 'when access method is "remote"' do
+      before(:each) do
+        allow(subject).to receive(:access_method).and_return(:remote)
+      end
 
-      allow(Hancock::Recipient::Recreator).to receive(:new)
-        .and_return(recreator)
-      expect(recreator).to receive(:recreate_with_tabs)
+      it 'updates the recipient and triggers a resend of the envelope' do
+        docusign_recipient = subject.send(:docusign_recipient)
+        expect(docusign_recipient).to receive(:update)
+          .with(
+            :recipientId => subject.identifier,
+            :name => subject.name,
+            :resend_envelope => true
+          )
 
-      subject.resend_email
+        subject.resend_email
+      end
+    end
+
+    context 'when access method is "embedded"' do
+      before(:each) do
+        allow(subject).to receive(:access_method).and_return(:embedded)
+      end
+
+      it 'entirely recreates the recipient' do
+        recreator = double(Hancock::Recipient::Recreator)
+
+        allow(Hancock::Recipient::Recreator).to receive(:new)
+          .and_return(recreator)
+        expect(recreator).to receive(:recreate_with_tabs)
+
+        subject.resend_email
+      end
     end
   end
 


### PR DESCRIPTION
- Add CC users
- Add embedded CC users (which have to be sent slightly differently)
- Refactor envelope creation to be more consistent