### PR TITLE
Allow non-unique email addresses on envelopes.

### DIFF
--- a/lib/hancock/envelope.rb
+++ b/lib/hancock/envelope.rb
@@ -254,14 +254,6 @@ module Hancock
 
     def recipient_validity
       check_collection_validity(:recipients, Recipient)
-
-      unless has_unique_emails?
-        errors.add(:recipients, 'must all have unique emails')
-      end
-    end
-
-    def has_unique_emails?
-      recipients.map { |r| r.try(:email) }.uniq.length == recipients.length
     end
 
     def document_validity

--- a/lib/hancock/version.rb
+++ b/lib/hancock/version.rb
@@ -1,3 +1,3 @@
 module Hancock
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end

--- a/spec/lib/envelope_spec.rb
+++ b/spec/lib/envelope_spec.rb
@@ -23,15 +23,6 @@ describe Hancock::Envelope do
     it { is_expected.not_to have_valid(:recipients).when([], nil, [:not_a_recipient], [association(Hancock::Recipient, :validity => false)]) }
     it { is_expected.to have_valid(:documents).when([association(Hancock::Document)]) }
     it { is_expected.not_to have_valid(:documents).when([], nil, [:not_a_document], [association(Hancock::Document, :validity => false)]) }
-
-    context 'recipients' do
-      it "validates uniqueness of emails" do
-        subject.recipients = [recipient, recipient]
-        subject.valid?
-
-        expect(subject.errors[:recipients]).to include("must all have unique emails")
-      end
-    end
   end
 
   context 'with valid envelope' do


### PR DESCRIPTION
- DocuSign allows multiple recipients on a single envelope to share the
  same email address, so we shouldn’t be blocking this!