### PR TITLE
Handle nested errorCode in response

### DIFF
--- a/lib/hancock/request.rb
+++ b/lib/hancock/request.rb
@@ -12,9 +12,9 @@ module Hancock
 
       Hancock.logger.info("#{type.upcase}: #{uri}\n#{options}")
 
-      if !response.success? || response["errorCode"].present?
+      if !response.success? || response.to_s.include?("errorCode")
         Hancock.logger.error("#{response.response.code}:\n#{response}")
-        fail RequestError, "#{response.response.code} - #{response['errorCode']} - #{response['message']}"
+        fail RequestError, "#{response.response.code} - #{response}"
       end
 
       Hancock.logger.debug("#{response.response.code}: #{response}")

--- a/spec/lib/envelope_spec.rb
+++ b/spec/lib/envelope_spec.rb
@@ -99,11 +99,12 @@ describe Hancock::Envelope do
       end
 
       it 'raises a DocusignError with the returned message if not successful' do
+        response = {"errorCode" => "UNEDUCATED_FELON_ERROR", "message" => "Umbrella smoothie is bad idea."}
         subject.identifier = 'smokey-heaven'
         stub_status_change('smokey-heaven', 'floosh', 'failed_status_change', 400)
         expect {
           subject.change_status!('floosh')
-        }.to raise_error(Hancock::Request::RequestError, '400 - UNEDUCATED_FELON_ERROR - Umbrella smoothie is bad idea.')
+        }.to raise_error(Hancock::Request::RequestError, "400 - #{response}")
       end
     end
 
@@ -316,11 +317,14 @@ describe Hancock::Envelope do
 
       context 'unsuccessful send' do
         let!(:request_stub) { stub_envelope_creation('send_envelope', 'failed_creation', 500) }
+        let(:response) {
+          {"errorCode" => "YOU_ARE_A_BANANA", "message" => "Bananas are not allowed to bank."}
+        }
 
         it 'raises a DocusignError with the returned message if not successful' do
           expect {
             subject.send!
-          }.to raise_error(Hancock::Request::RequestError, '500 - YOU_ARE_A_BANANA - Bananas are not allowed to bank.')
+          }.to raise_error(Hancock::Request::RequestError, "500 - #{response}")
         end
       end
     end

--- a/spec/lib/request_spec.rb
+++ b/spec/lib/request_spec.rb
@@ -4,6 +4,21 @@ describe Hancock::Request do
     allow(Hancock).to receive(:oauth_token).and_return('AnAmazingOAuthTokenShinyAndPink')
   end
 
+  let(:response_with_error) {
+    { "errorCode" => "WANNA", "message" => "An error message" }
+  }
+
+  let(:response_with_nested_error) {
+    {
+      "someResultsForYou" => [{
+        "nestedStuff" => {
+          "errorCode" =>"REQU3STLY_NO-BUENo",
+          "message" => "Trust not the 200"
+        }
+      }]
+    }
+  }
+
   describe '#send_get_request' do
     it 'sends a request and receives a parsed body' do
       stub_request(:get, 'https://demo.docusign.net/restapi/v2/accounts/123456/something_exciting')
@@ -25,22 +40,22 @@ describe Hancock::Request do
       stub_request(:get, 'https://demo.docusign.net/restapi/v2/accounts/123456/something_exciting')
         .to_return(
           :status => 404,
-          :body => { :errorCode => 'WANNA', :message => 'An error message' }.to_json,
+          :body => response_with_error.to_json,
           :headers => { 'Content-Type' => 'application/json' })
       expect {
         described_class.send_get_request('/something_exciting')
-      }.to raise_error(Hancock::Request::RequestError, '404 - WANNA - An error message')
+      }.to raise_error(Hancock::Request::RequestError, "404 - #{response_with_error}")
     end
 
     it "raises an error if an error code is present regardless of http status" do
       stub_request(:get, "https://demo.docusign.net/restapi/v2/accounts/123456/something_subtly_broken")
         .to_return(
           :status => 200,
-          :body => { :errorCode => "Oops", :message => "I'm good, no I'm not" }.to_json,
+          :body => response_with_nested_error.to_json,
           :headers => { "Content-Type" => 'application/json' })
       expect {
         described_class.send_get_request("/something_subtly_broken")
-      }.to raise_error(Hancock::Request::RequestError, "200 - Oops - I'm good, no I'm not")
+      }.to raise_error(Hancock::Request::RequestError, "200 - #{response_with_nested_error}")
     end
   end
 
@@ -66,22 +81,33 @@ describe Hancock::Request do
       stub_request(:delete, 'https://demo.docusign.net/restapi/v2/accounts/123456/something_exciting')
         .to_return(
           :status => 404,
-          :body => { :errorCode => 'WANNA', :message => 'An error message' }.to_json,
+          :body => response_with_error.to_json,
           :headers => { 'Content-Type' => 'application/json' })
       expect {
         described_class.send_delete_request('/something_exciting', '{}')
-      }.to raise_error(Hancock::Request::RequestError, '404 - WANNA - An error message')
+      }.to raise_error(Hancock::Request::RequestError, "404 - #{response_with_error}")
     end
 
     it "raises an error if an error code is present regardless of http status" do
       stub_request(:delete, "https://demo.docusign.net/restapi/v2/accounts/123456/something_subtly_broken")
         .to_return(
           :status => 200,
-          :body => { :errorCode => "Oops", :message => "I'm good, no I'm not" }.to_json,
+          :body => response_with_nested_error.to_json,
           :headers => { "Content-Type" => 'application/json' })
       expect {
         described_class.send_delete_request("/something_subtly_broken", "{}")
-      }.to raise_error(Hancock::Request::RequestError, "200 - Oops - I'm good, no I'm not")
+      }.to raise_error(Hancock::Request::RequestError, "200 - #{response_with_nested_error}")
+    end
+
+    it "raises an error if an error code is present regardless of http status" do
+      stub_request(:post, "https://demo.docusign.net/restapi/v2/accounts/123456/something_subtly_broken")
+        .to_return(
+          :status => 200,
+          :body => response_with_nested_error.to_json,
+          :headers => { "Content-Type" => 'application/json' })
+      expect {
+        described_class.send_post_request("/something_subtly_broken", "ignorance isn't bliss")
+      }.to raise_error(Hancock::Request::RequestError, "200 - #{response_with_nested_error}")
     end
   end
 
@@ -107,22 +133,22 @@ describe Hancock::Request do
       stub_request(:post, 'https://demo.docusign.net/restapi/v2/accounts/123456/something_exciting')
         .to_return(
           :status => 404,
-          :body => { :errorCode => 'WANNA', :message => 'An error message' }.to_json,
+          :body => response_with_error.to_json,
           :headers => { 'Content-Type' => 'application/json' })
       expect {
         described_class.send_post_request('/something_exciting', 'alien sandwiches')
-      }.to raise_error(Hancock::Request::RequestError, '404 - WANNA - An error message')
+      }.to raise_error(Hancock::Request::RequestError, "404 - #{response_with_error}")
     end
 
     it "raises an error if an error code is present regardless of http status" do
       stub_request(:post, "https://demo.docusign.net/restapi/v2/accounts/123456/something_subtly_broken")
         .to_return(
           :status => 200,
-          :body => { :errorCode => "Oops", :message => "I'm good, no I'm not" }.to_json,
+          :body => response_with_nested_error.to_json,
           :headers => { "Content-Type" => 'application/json' })
       expect {
         described_class.send_post_request("/something_subtly_broken", "ignorance isn't bliss")
-      }.to raise_error(Hancock::Request::RequestError, "200 - Oops - I'm good, no I'm not")
+      }.to raise_error(Hancock::Request::RequestError, "200 - #{response_with_nested_error}")
     end
   end
 
@@ -149,22 +175,22 @@ describe Hancock::Request do
       stub_request(:put, 'https://demo.docusign.net/restapi/v2/accounts/123456/something_exciting')
         .to_return(
           :status => 404,
-          :body => { :errorCode => 'WANNA', :message => 'An error message' }.to_json,
+          :body => response_with_error.to_json,
           :headers => { 'Content-Type' => 'application/json' })
       expect {
         described_class.send_put_request('/something_exciting', 'you will rue bidets')
-      }.to raise_error(Hancock::Request::RequestError, '404 - WANNA - An error message')
+      }.to raise_error(Hancock::Request::RequestError, "404 - #{response_with_error}")
     end
 
     it "raises an error if an error code is present regardless of http status" do
       stub_request(:put, "https://demo.docusign.net/restapi/v2/accounts/123456/something_subtly_broken")
         .to_return(
           :status => 200,
-          :body => { :errorCode => "Oops", :message => "I'm good, no I'm not" }.to_json,
+          :body => response_with_nested_error.to_json,
           :headers => { "Content-Type" => "application/json" })
       expect {
         described_class.send_put_request("/something_subtly_broken", "ignorance isn't bliss")
-      }.to raise_error(Hancock::Request::RequestError, "200 - Oops - I'm good, no I'm not")
+      }.to raise_error(Hancock::Request::RequestError, "200 - #{response_with_nested_error}")
     end
   end
 


### PR DESCRIPTION
Some 200 responses have `errorCode` as a top-level key. Others nest it
somewhere deeper in the JSON. This is a quick fix to detect errors. A
more complete fix would be to detect which portions of the request
had errors (e.g. which specific recipients we attempted to update failed 
to update).