### PR TITLE
Handle nested errorCode in response

### DIFF
--- a/lib/hancock/request.rb
+++ b/lib/hancock/request.rb
@@ -12,9 +12,9 @@ module Hancock
 
       Hancock.logger.info("#{type.upcase}: #{uri}\n#{options}")
 
-      if !response.success? || response["errorCode"].present?
+      if !response.success? || response.to_s.include?("errorCode")
         Hancock.logger.error("#{response.response.code}:\n#{response}")
-        fail RequestError, "#{response.response.code} - #{response['errorCode']} - #{response['message']}"
+        fail RequestError, "#{response.response.code} - #{response}"
       end
 
       Hancock.logger.debug("#{response.response.code}: #{response}")

--- a/lib/hancock/request.rb
+++ b/lib/hancock/request.rb
@@ -4,15 +4,57 @@ module Hancock
   class Request
     RequestError = Class.new(StandardError)
 
-    def self.send_request(type, url, headers, body = nil)
-      uri = build_uri(url)
-      options = { :headers => headers }
-      options[:body] = body if body
-      response = HTTParty.send(type, uri, options)
+    attr_reader :uri, :type, :headers, :body, :response
+
+    class << self
+      def send_post_request(url, body, custom_headers = {})
+        new(
+          :type => :post,
+          :url => url,
+          :custom_headers => custom_headers,
+          :body => body
+        ).send_request
+      end
+
+      def send_put_request(url, body, custom_headers = {})
+        new(
+          :type => :put,
+          :url => url,
+          :custom_headers => custom_headers,
+          :body => body
+        ).send_request
+      end
+
+      def send_get_request(url)
+        new(
+          :type => :get,
+          :url => url
+        ).send_request
+      end
+
+      def send_delete_request(url, body, custom_headers = {})
+        new(
+          :type => :delete,
+          :url => url,
+          :custom_headers => custom_headers,
+          :body => body
+        ).send_request
+      end
+    end
+
+    def initialize(type:, url:, custom_headers: {}, body: nil)
+      @type = type
+      @uri = build_uri(url)
+      @headers = default_headers.merge(custom_headers)
+      @body = body
+    end
+
+    def send_request
+      @response = HTTParty.send(type, uri, options)
 
       Hancock.logger.info("#{type.upcase}: #{uri}\n#{options}")
 
-      if !response.success? || self.has_error?(response)
+      unless success?
         Hancock.logger.error("#{response.response.code}:\n#{response}")
         fail RequestError, "#{response.response.code} - #{response}"
       end
@@ -22,68 +64,41 @@ module Hancock
       response
     end
 
-    #
-    # send post request to set uri with post body and headers
-    #
-    def self.send_post_request(url, body_post, headers = {})
-      send_request(:post, url, merge_headers(headers), body_post)
-    end
+    private
 
-    #
-    # send put request to set url
-    #
-    def self.send_put_request(url, body_post, headers = {})
-      send_request(:put, url, merge_headers(headers), body_post)
-    end
-
-    #
-    # send get request to set url
-    #
-    def self.send_get_request(url)
-      send_request(:get, url, merge_headers)
-    end
-
-    #
-    # send delete request to set url
-    #
-    def self.send_delete_request(url, body_post, headers = {})
-      send_request(:delete, url, merge_headers(headers), body_post)
-    end
-
-    #
-    # generate common uri to docusign service
-    #
-    def self.build_uri(url)
-      "#{Hancock.endpoint}/#{Hancock.api_version}/accounts/#{Hancock.account_id}#{url}"
-    end
-
-    #
-    # Merge default headers with these headers
-    #
-    def self.merge_headers(user_defined_headers = {})
-      default_headers = {
+    def default_headers
+      {
         'Accept' => 'application/json',
         'Authorization' => "bearer #{Hancock.oauth_token}",
         'Content-Type' => 'application/json'
       }
-
-      user_defined_headers.each do |key, value|
-        default_headers[key] = value
-      end
-
-      default_headers
     end
 
-    def self.has_error?(response)
+    def options
+      {
+        :headers => headers,
+        :body => body
+      }
+    end
+
+    def build_uri(url)
+      "#{Hancock.endpoint}/#{Hancock.api_version}/accounts/#{Hancock.account_id}#{url}"
+    end
+
+    def success?
+      response.success? && !has_error?
+    end
+
+    def has_error?
       if response.content_type == "application/json"
-        self.includes_error_code?(JSON.parse(response.body))
+        includes_error_code?(JSON.parse(response.body))
       end
     end
 
-    def self.includes_error_code?(data)
+    def includes_error_code?(data)
       case data
       when Hash
-        if data.fetch("errorCode", "SUCCESS") != "SUCCESS"
+        if data.has_key?("errorCode") && data["errorCode"] != "SUCCESS"
           true
         else
           data.values.any? { |element| includes_error_code?(element) }

--- a/lib/hancock/version.rb
+++ b/lib/hancock/version.rb
@@ -1,3 +1,3 @@
 module Hancock
-  VERSION = '0.7.2'
+  VERSION = '0.7.3'
 end

--- a/lib/hancock/version.rb
+++ b/lib/hancock/version.rb
@@ -1,3 +1,3 @@
 module Hancock
-  VERSION = '0.7.3'
+  VERSION = '0.7.4'
 end

--- a/spec/lib/envelope_spec.rb
+++ b/spec/lib/envelope_spec.rb
@@ -99,11 +99,12 @@ describe Hancock::Envelope do
       end
 
       it 'raises a DocusignError with the returned message if not successful' do
+        response = {"errorCode" => "UNEDUCATED_FELON_ERROR", "message" => "Umbrella smoothie is bad idea."}
         subject.identifier = 'smokey-heaven'
         stub_status_change('smokey-heaven', 'floosh', 'failed_status_change', 400)
         expect {
           subject.change_status!('floosh')
-        }.to raise_error(Hancock::Request::RequestError, '400 - UNEDUCATED_FELON_ERROR - Umbrella smoothie is bad idea.')
+        }.to raise_error(Hancock::Request::RequestError, "400 - #{response}")
       end
     end
 
@@ -316,11 +317,14 @@ describe Hancock::Envelope do
 
       context 'unsuccessful send' do
         let!(:request_stub) { stub_envelope_creation('send_envelope', 'failed_creation', 500) }
+        let(:response) {
+          {"errorCode" => "YOU_ARE_A_BANANA", "message" => "Bananas are not allowed to bank."}
+        }
 
         it 'raises a DocusignError with the returned message if not successful' do
           expect {
             subject.send!
-          }.to raise_error(Hancock::Request::RequestError, '500 - YOU_ARE_A_BANANA - Bananas are not allowed to bank.')
+          }.to raise_error(Hancock::Request::RequestError, "500 - #{response}")
         end
       end
     end

--- a/spec/lib/request_spec.rb
+++ b/spec/lib/request_spec.rb
@@ -4,6 +4,21 @@ describe Hancock::Request do
     allow(Hancock).to receive(:oauth_token).and_return('AnAmazingOAuthTokenShinyAndPink')
   end
 
+  let(:response_with_error) {
+    { "errorCode" => "WANNA", "message" => "An error message" }
+  }
+
+  let(:response_with_nested_error) {
+    {
+      "someResultsForYou" => [{
+        "nestedStuff" => {
+          "errorCode" =>"REQU3STLY_NO-BUENo",
+          "message" => "Trust not the 200"
+        }
+      }]
+    }
+  }
+
   describe '#send_get_request' do
     it 'sends a request and receives a parsed body' do
       stub_request(:get, 'https://demo.docusign.net/restapi/v2/accounts/123456/something_exciting')
@@ -25,22 +40,22 @@ describe Hancock::Request do
       stub_request(:get, 'https://demo.docusign.net/restapi/v2/accounts/123456/something_exciting')
         .to_return(
           :status => 404,
-          :body => { :errorCode => 'WANNA', :message => 'An error message' }.to_json,
+          :body => response_with_error.to_json,
           :headers => { 'Content-Type' => 'application/json' })
       expect {
         described_class.send_get_request('/something_exciting')
-      }.to raise_error(Hancock::Request::RequestError, '404 - WANNA - An error message')
+      }.to raise_error(Hancock::Request::RequestError, "404 - #{response_with_error}")
     end
 
     it "raises an error if an error code is present regardless of http status" do
       stub_request(:get, "https://demo.docusign.net/restapi/v2/accounts/123456/something_subtly_broken")
         .to_return(
           :status => 200,
-          :body => { :errorCode => "Oops", :message => "I'm good, no I'm not" }.to_json,
+          :body => response_with_nested_error.to_json,
           :headers => { "Content-Type" => 'application/json' })
       expect {
         described_class.send_get_request("/something_subtly_broken")
-      }.to raise_error(Hancock::Request::RequestError, "200 - Oops - I'm good, no I'm not")
+      }.to raise_error(Hancock::Request::RequestError, "200 - #{response_with_nested_error}")
     end
   end
 
@@ -66,22 +81,22 @@ describe Hancock::Request do
       stub_request(:delete, 'https://demo.docusign.net/restapi/v2/accounts/123456/something_exciting')
         .to_return(
           :status => 404,
-          :body => { :errorCode => 'WANNA', :message => 'An error message' }.to_json,
+          :body => response_with_error.to_json,
           :headers => { 'Content-Type' => 'application/json' })
       expect {
         described_class.send_delete_request('/something_exciting', '{}')
-      }.to raise_error(Hancock::Request::RequestError, '404 - WANNA - An error message')
+      }.to raise_error(Hancock::Request::RequestError, "404 - #{response_with_error}")
     end
 
     it "raises an error if an error code is present regardless of http status" do
       stub_request(:delete, "https://demo.docusign.net/restapi/v2/accounts/123456/something_subtly_broken")
         .to_return(
           :status => 200,
-          :body => { :errorCode => "Oops", :message => "I'm good, no I'm not" }.to_json,
+          :body => response_with_nested_error.to_json,
           :headers => { "Content-Type" => 'application/json' })
       expect {
         described_class.send_delete_request("/something_subtly_broken", "{}")
-      }.to raise_error(Hancock::Request::RequestError, "200 - Oops - I'm good, no I'm not")
+      }.to raise_error(Hancock::Request::RequestError, "200 - #{response_with_nested_error}")
     end
   end
 
@@ -107,22 +122,22 @@ describe Hancock::Request do
       stub_request(:post, 'https://demo.docusign.net/restapi/v2/accounts/123456/something_exciting')
         .to_return(
           :status => 404,
-          :body => { :errorCode => 'WANNA', :message => 'An error message' }.to_json,
+          :body => response_with_error.to_json,
           :headers => { 'Content-Type' => 'application/json' })
       expect {
         described_class.send_post_request('/something_exciting', 'alien sandwiches')
-      }.to raise_error(Hancock::Request::RequestError, '404 - WANNA - An error message')
+      }.to raise_error(Hancock::Request::RequestError, "404 - #{response_with_error}")
     end
 
     it "raises an error if an error code is present regardless of http status" do
       stub_request(:post, "https://demo.docusign.net/restapi/v2/accounts/123456/something_subtly_broken")
         .to_return(
           :status => 200,
-          :body => { :errorCode => "Oops", :message => "I'm good, no I'm not" }.to_json,
+          :body => response_with_nested_error.to_json,
           :headers => { "Content-Type" => 'application/json' })
       expect {
         described_class.send_post_request("/something_subtly_broken", "ignorance isn't bliss")
-      }.to raise_error(Hancock::Request::RequestError, "200 - Oops - I'm good, no I'm not")
+      }.to raise_error(Hancock::Request::RequestError, "200 - #{response_with_nested_error}")
     end
   end
 
@@ -149,22 +164,22 @@ describe Hancock::Request do
       stub_request(:put, 'https://demo.docusign.net/restapi/v2/accounts/123456/something_exciting')
         .to_return(
           :status => 404,
-          :body => { :errorCode => 'WANNA', :message => 'An error message' }.to_json,
+          :body => response_with_error.to_json,
           :headers => { 'Content-Type' => 'application/json' })
       expect {
         described_class.send_put_request('/something_exciting', 'you will rue bidets')
-      }.to raise_error(Hancock::Request::RequestError, '404 - WANNA - An error message')
+      }.to raise_error(Hancock::Request::RequestError, "404 - #{response_with_error}")
     end
 
     it "raises an error if an error code is present regardless of http status" do
       stub_request(:put, "https://demo.docusign.net/restapi/v2/accounts/123456/something_subtly_broken")
         .to_return(
           :status => 200,
-          :body => { :errorCode => "Oops", :message => "I'm good, no I'm not" }.to_json,
+          :body => response_with_nested_error.to_json,
           :headers => { "Content-Type" => "application/json" })
       expect {
         described_class.send_put_request("/something_subtly_broken", "ignorance isn't bliss")
-      }.to raise_error(Hancock::Request::RequestError, "200 - Oops - I'm good, no I'm not")
+      }.to raise_error(Hancock::Request::RequestError, "200 - #{response_with_nested_error}")
     end
   end
 

--- a/spec/lib/request_spec.rb
+++ b/spec/lib/request_spec.rb
@@ -1,206 +1,234 @@
 describe Hancock::Request do
-  before do
-    allow(Hancock).to receive(:account_id).and_return(123_456)
-    allow(Hancock).to receive(:oauth_token).and_return('AnAmazingOAuthTokenShinyAndPink')
+  before(:each) do
+    allow(Hancock).to receive(:oauth_token).and_return("a_tokeny_value")
   end
 
-  let(:response_with_error) {
-    { "errorCode" => "WANNA", "message" => "An error message" }
-  }
+  describe ".send_post_request" do
+    subject { instance_double(Hancock::Request) }
 
-  let(:response_with_nested_error) {
-    {
-      "someResultsForYou" => [{
-        "nestedStuff" => {
-          "errorCode" =>"REQU3STLY_NO-BUENo",
-          "message" => "Trust not the 200"
-        }
-      }]
-    }
-  }
-
-  describe '#send_get_request' do
-    it 'sends a request and receives a parsed body' do
-      stub_request(:get, 'https://demo.docusign.net/restapi/v2/accounts/123456/something_exciting')
+    it "creates an instance and sends the request" do
+      expect(described_class).to receive(:new)
         .with(
-          :headers => {
-            'Accept' => 'application/json',
-            'Authorization' => 'bearer AnAmazingOAuthTokenShinyAndPink'
-          })
-        .to_return(
-          :status => 200,
-          :body => '{"message": "the body"}',
-          :headers => { 'Content-Type' => 'application/json' })
-      response = described_class.send_get_request('/something_exciting')
-      expect(response.success?).to be_truthy
-      expect(response.parsed_response).to eq({'message' => 'the body'})
-    end
-
-    it 'raises an error for any non-200 response status' do
-      stub_request(:get, 'https://demo.docusign.net/restapi/v2/accounts/123456/something_exciting')
-        .to_return(
-          :status => 404,
-          :body => response_with_error.to_json,
-          :headers => { 'Content-Type' => 'application/json' })
-      expect {
-        described_class.send_get_request('/something_exciting')
-      }.to raise_error(Hancock::Request::RequestError, "404 - #{response_with_error}")
-    end
-
-    it "raises an error if an error code is present regardless of http status" do
-      stub_request(:get, "https://demo.docusign.net/restapi/v2/accounts/123456/something_subtly_broken")
-        .to_return(
-          :status => 200,
-          :body => response_with_nested_error.to_json,
-          :headers => { "Content-Type" => 'application/json' })
-      expect {
-        described_class.send_get_request("/something_subtly_broken")
-      }.to raise_error(Hancock::Request::RequestError, "200 - #{response_with_nested_error}")
+          :type => :post,
+          :url => "a_url",
+          :custom_headers => {"custom" => "header"},
+          :body => "a_body"
+        ).and_return(subject)
+      expect(subject).to receive(:send_request)
+      described_class.send_post_request("a_url", "a_body", "custom" => "header")
     end
   end
 
-  describe '#send_delete_request' do
-    it 'sends a delete request to DocuSign and returns response' do
-      stub_request(:delete, 'https://demo.docusign.net/restapi/v2/accounts/123456/something_exciting')
+  describe ".send_put_request" do
+    subject { instance_double(Hancock::Request) }
+
+    it "creates an instance and sends the request" do
+      expect(described_class).to receive(:new)
         .with(
-          :headers => {
-            'Accept' => 'application/json',
-            'Authorization' => 'bearer AnAmazingOAuthTokenShinyAndPink',
-            'Content-Type' => 'application/json'
-          })
-        .to_return(
-          :status => 200,
-          :body => '{"message": "the body"}',
-          :headers => { 'Content-Type' => 'application/json' })
-      response = described_class.send_delete_request('/something_exciting', '{}')
-      expect(response.success?).to be_truthy
-      expect(response.parsed_response).to eq({'message' => 'the body'})
-    end
-
-    it 'raises an error for any non-200 response status' do
-      stub_request(:delete, 'https://demo.docusign.net/restapi/v2/accounts/123456/something_exciting')
-        .to_return(
-          :status => 404,
-          :body => response_with_error.to_json,
-          :headers => { 'Content-Type' => 'application/json' })
-      expect {
-        described_class.send_delete_request('/something_exciting', '{}')
-      }.to raise_error(Hancock::Request::RequestError, "404 - #{response_with_error}")
-    end
-
-    it "raises an error if an error code is present regardless of http status" do
-      stub_request(:delete, "https://demo.docusign.net/restapi/v2/accounts/123456/something_subtly_broken")
-        .to_return(
-          :status => 200,
-          :body => response_with_nested_error.to_json,
-          :headers => { "Content-Type" => 'application/json' })
-      expect {
-        described_class.send_delete_request("/something_subtly_broken", "{}")
-      }.to raise_error(Hancock::Request::RequestError, "200 - #{response_with_nested_error}")
+          :type => :put,
+          :url => "a_url",
+          :custom_headers => {"custom" => "header"},
+          :body => "a_body"
+        ).and_return(subject)
+      expect(subject).to receive(:send_request)
+      described_class.send_put_request("a_url", "a_body", "custom" => "header")
     end
   end
 
-  describe '#send_post_request' do
-    it 'sends a post request to DocuSign and returns response' do
-      stub_request(:post, 'https://demo.docusign.net/restapi/v2/accounts/123456/whatever')
+  describe ".send_get_request" do
+    subject { instance_double(Hancock::Request) }
+
+    it "creates an instance and sends the request" do
+      expect(described_class).to receive(:new)
+        .with(:type => :get, :url => "a_url")
+        .and_return(subject)
+      expect(subject).to receive(:send_request)
+      described_class.send_get_request("a_url")
+    end
+  end
+
+  describe ".send_delete_request" do
+    subject { instance_double(Hancock::Request) }
+
+    it "creates an instance and sends the request" do
+      expect(described_class).to receive(:new)
         .with(
-          :headers => {
-            'Accept' => 'Yourself',
-            'Authorization' => 'bearer AnAmazingOAuthTokenShinyAndPink',
-          },
-          :body => 'alien sandwiches')
-        .to_return(
-          :status => 201,
-          :body => '{"message": "bodylicious"}',
-          :headers => { 'Content-Type' => 'application/json' })
-      response = described_class.send_post_request('/whatever', 'alien sandwiches', 'Accept' => 'Yourself')
-      expect(response.success?).to be true
-      expect(response.parsed_response).to eq({ 'message' => 'bodylicious' })
-    end
-
-    it 'raises an error for any non-200 response status' do
-      stub_request(:post, 'https://demo.docusign.net/restapi/v2/accounts/123456/something_exciting')
-        .to_return(
-          :status => 404,
-          :body => response_with_error.to_json,
-          :headers => { 'Content-Type' => 'application/json' })
-      expect {
-        described_class.send_post_request('/something_exciting', 'alien sandwiches')
-      }.to raise_error(Hancock::Request::RequestError, "404 - #{response_with_error}")
-    end
-
-    it "raises an error if an error code is present regardless of http status" do
-      stub_request(:post, "https://demo.docusign.net/restapi/v2/accounts/123456/something_subtly_broken")
-        .to_return(
-          :status => 200,
-          :body => response_with_nested_error.to_json,
-          :headers => { "Content-Type" => 'application/json' })
-      expect {
-        described_class.send_post_request("/something_subtly_broken", "ignorance isn't bliss")
-      }.to raise_error(Hancock::Request::RequestError, "200 - #{response_with_nested_error}")
+          :type => :delete,
+          :url => "a_url",
+          :custom_headers => {"custom" => "header"},
+          :body => "a_body"
+        ).and_return(subject)
+      expect(subject).to receive(:send_request)
+      described_class.send_delete_request("a_url", "a_body", "custom" => "header")
     end
   end
 
-  describe '#send_put_request' do
-    it 'sends a put request to DocuSign and returns response' do
-      stub_request(:put, 'https://demo.docusign.net/restapi/v2/accounts/123456/ghost_racquetball')
-        .with(
-          :headers => {
-            'Accept' => 'application/json',
-            'Authorization' => 'bearer AnAmazingOAuthTokenShinyAndPink',
-            'Content-Type' => 'application/json'
-          },
-          :body => 'you will rue bidets')
-        .to_return(
-          :status => 200,
-          :body => '{ "message": "grassy knolls" }',
-          :headers => { 'Content-Type' => 'application/json' })
-      response = described_class.send_put_request('/ghost_racquetball', 'you will rue bidets')
-      expect(response.success?).to be_truthy
-      expect(response.parsed_response).to eq('message' => 'grassy knolls')
+  describe "#initialize" do
+    it "uses default headers" do
+      subject = described_class.new(:type => :foo, :url => :bar)
+
+      expect(subject.headers).to eq({
+        "Accept" => "application/json",
+        "Authorization" => "bearer a_tokeny_value",
+        "Content-Type" => "application/json"
+      })
     end
 
-    it 'raises an error for any non-200 response status' do
-      stub_request(:put, 'https://demo.docusign.net/restapi/v2/accounts/123456/something_exciting')
-        .to_return(
-          :status => 404,
-          :body => response_with_error.to_json,
-          :headers => { 'Content-Type' => 'application/json' })
-      expect {
-        described_class.send_put_request('/something_exciting', 'you will rue bidets')
-      }.to raise_error(Hancock::Request::RequestError, "404 - #{response_with_error}")
-    end
-
-    it "raises an error if an error code is present regardless of http status" do
-      stub_request(:put, "https://demo.docusign.net/restapi/v2/accounts/123456/something_subtly_broken")
-        .to_return(
-          :status => 200,
-          :body => response_with_nested_error.to_json,
-          :headers => { "Content-Type" => "application/json" })
-      expect {
-        described_class.send_put_request("/something_subtly_broken", "ignorance isn't bliss")
-      }.to raise_error(Hancock::Request::RequestError, "200 - #{response_with_nested_error}")
-    end
-  end
-
-  describe '#merge_headers' do
-    let(:default_headers) {
-      {
-        'Accept' => 'application/json',
-        'Authorization' => 'bearer AnAmazingOAuthTokenShinyAndPink',
-        'Content-Type' => 'application/json'
+    it "allows custom headers to override default headers" do
+      custom_headers = {
+        "Nature" => "secret",
+        "Accept" => "EvEryThinG!"
       }
-    }
+      subject = described_class.new(
+        :type => :foo,
+        :url => :bar,
+        :custom_headers => custom_headers
+      )
 
-    it "returns Accept and Authorization headers" do
-      expect(described_class.merge_headers).to eq default_headers
+      expect(subject.headers).to eq({
+        "Nature" => "secret",
+        "Accept" => "EvEryThinG!",
+        "Authorization" => "bearer a_tokeny_value",
+        "Content-Type" => "application/json"
+      })
     end
 
-    it 'merges given headers with default headers' do
-      content_headers = { 'Content-Type' => "multipart/form-data, boundary='AAA'"}
+    it "allows a body to be specified" do
+      subject = described_class.new(
+        :type => :foo,
+        :url => :bar,
+        :custom_headers => {},
+        :body => "the body"
+      )
+      expect(subject.body).to eq("the body")
+    end
 
-      expect(described_class.merge_headers(content_headers)).
-        to eq default_headers.merge!(content_headers)
+    it "generates the uri" do
+      allow(Hancock).to receive(:endpoint).and_return("3ndp0int")
+      allow(Hancock).to receive(:api_version).and_return("l@test")
+      allow(Hancock).to receive(:account_id).and_return("acc0unt")
+
+      subject = described_class.new(:type => :foo, :url => "/awesome_path")
+
+      expect(subject.uri).to eq("3ndp0int/l@test/accounts/acc0unt/awesome_path")
+    end
+  end
+
+  describe "#send_request" do
+    subject {
+      described_class.new(
+        :type => :the_type,
+        :url => "whatever",
+        :custom_headers => {},
+        body: "the content"
+      )
+    }
+
+    before(:each) do
+      allow(subject).to receive(:uri).and_return(:the_uri)
+      allow(subject).to receive(:headers).and_return(:the_headers)
+    end
+
+    context "for successful requests" do
+      let(:httparty_response) {
+        double(
+          :success? => true,
+          :content_type => "application/json",
+          :body => "{}",
+          :response => double(:code => "200")
+        )
+      }
+
+      before(:each) do
+        allow(HTTParty).to receive(:send).and_return(httparty_response)
+      end
+
+      it "sends the request via HTTParty" do
+        expect(HTTParty).to receive(:send).with(
+          :the_type,
+          :the_uri,
+          { :headers => :the_headers, :body => "the content" }
+        ).and_return(httparty_response)
+
+        subject.send_request
+      end
+
+      it "returns the HTTParty response" do
+        expect(subject.send_request).to eq(httparty_response)
+      end
+    end
+
+    context "for requests with a non-200-level HTTP status" do
+      let(:httparty_response) {
+        double(
+          :success? => false,
+          :body => "{}",
+          :response => double(:code => "whatever")
+        )
+      }
+
+      before(:each) do
+        allow(HTTParty).to receive(:send).and_return(httparty_response)
+      end
+
+      it "raises an exception" do
+        expect{ subject.send_request }.to raise_error(Hancock::Request::RequestError)
+      end
+    end
+
+    context "for requests that contain an errorCode" do
+      let(:httparty_response) {
+        double(
+          :success? => true,
+          :content_type => "application/json",
+          :body => body,
+          :response => double(:code => "whatever")
+        )
+      }
+
+      before(:each) do
+        allow(HTTParty).to receive(:send).and_return(httparty_response)
+      end
+
+      context "when the errorCode is a top-level key" do
+        let(:body) {
+          { "errorCode" =>"REQU3STLY_NO-BUENo" }.to_json
+        }
+
+        it "raises an exception" do
+          expect{ subject.send_request }.to raise_error(Hancock::Request::RequestError)
+        end
+      end
+
+      context "when the errorCode is nested" do
+        let(:body) {
+          {
+            "someResultsForYou" => [
+              { "foo" => "bar" },
+              {
+                "nestedStuff" => {
+                  "errorCode" =>"REQU3STLY_NO-BUENo",
+                  "message" => "Trust not the 200"
+                }
+              }
+            ]
+          }.to_json
+        }
+
+        it "raises an exception" do
+          expect{ subject.send_request }.to raise_error(Hancock::Request::RequestError)
+        end
+      end
+
+      context "when the errorCode is 'SUCCESS'" do
+        let(:body) {
+          { "errorCode" =>"SUCCESS" }.to_json
+        }
+
+        it "does not raise an exception" do
+          expect{ subject.send_request }.not_to raise_error
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Some 200 responses have `errorCode` as a top-level key. Others nest it
somewhere deeper in the JSON. This is a quick fix to detect errors. A
more complete fix would be to detect which portions of the request
had errors (e.g. which specific recipients we attempted to update failed 
to update).