### PR TITLE
Replace HTTParty with Faraday

### DIFF
--- a/hancock.gemspec
+++ b/hancock.gemspec
@@ -33,6 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport'
   spec.add_dependency 'faraday'            # http library
   spec.add_dependency 'faraday_middleware' # allows redirects
-  spec.add_dependency 'typhoeus'           # runs http requests in parallel
   spec.add_dependency 'activemodel'
 end

--- a/hancock.gemspec
+++ b/hancock.gemspec
@@ -31,6 +31,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "nokogiri"
   spec.add_dependency 'activesupport'
-  spec.add_dependency 'httparty'
+  spec.add_dependency 'faraday'            # http library
+  spec.add_dependency 'faraday_middleware' # allows redirects
+  spec.add_dependency 'typhoeus'           # runs http requests in parallel
   spec.add_dependency 'activemodel'
 end

--- a/lib/hancock/configuration.rb
+++ b/lib/hancock/configuration.rb
@@ -25,6 +25,7 @@ module Hancock
     DEFAULT_CA_FILE        = nil
     DEFAULT_FORMAT         = :json
     DEFAULT_EMAIL_TEMPLATE = {}
+    DEFAULT_LOGGER         = Logger.new($stdout)
     DEFAULT_EVENT_NOTIFICATION = {
       :logging_enabled => false,
       :uri => 'http://domain.com/hancock/process_callback',
@@ -51,7 +52,7 @@ module Hancock
       self.event_notification = DEFAULT_EVENT_NOTIFICATION
       self.boundary           = DEFAULT_BOUNDARY
       self.placeholder_email  = DEFAULT_PLACEHOLDER_EMAIL
-      self.logger             = Logger.new($stdout)
+      self.logger             = DEFAULT_LOGGER
     end
 
     def configure

--- a/lib/hancock/docusign_adapter.rb
+++ b/lib/hancock/docusign_adapter.rb
@@ -24,7 +24,7 @@ module Hancock
     # This retrieves the specified document from the envelope
     #
     def document(document_id)
-      Hancock::Request.send_get_request("/envelopes/#{envelope_id}/documents/#{document_id}").body
+      Hancock::Request.send_get_request("/envelopes/#{envelope_id}/documents/#{document_id}")
     end
 
     #

--- a/lib/hancock/envelope.rb
+++ b/lib/hancock/envelope.rb
@@ -89,7 +89,7 @@ module Hancock
     def change_status!(status)
       fail NotSavedYet unless identifier
       put_body = { :status => status }.to_json
-      response = Hancock::Request.send_put_request("/envelopes/#{identifier}", put_body)
+      Hancock::Request.send_put_request("/envelopes/#{identifier}", put_body)
       reload!
     end
 
@@ -118,8 +118,7 @@ module Hancock
     end
 
     def current_routing_order
-      Recipient::DocusignRecipient.all_for(identifier)
-        .parsed_response['currentRoutingOrder'].to_i
+      Recipient::DocusignRecipient.all_for(identifier)["currentRoutingOrder"].to_i
     end
 
     def notification_for_params

--- a/lib/hancock/recipient.rb
+++ b/lib/hancock/recipient.rb
@@ -38,7 +38,7 @@ module Hancock
     end
 
     def self.fetch_for_envelope(envelope_identifier)
-      parsed_response = DocusignRecipient.all_for(envelope_identifier).parsed_response
+      parsed_response = DocusignRecipient.all_for(envelope_identifier)
 
       TYPES.map do |type|
         parsed_response[docusign_recipient_type(type)].map do |envelope_recipient|
@@ -105,7 +105,7 @@ module Hancock
         fail SigningUrlError, 'This recipient is not setup for in-person signing'
       end
 
-      docusign_recipient.signing_url(return_url).parsed_response['url']
+      docusign_recipient.signing_url(return_url)["url"]
     end
 
     def create(envelope_identifier: )

--- a/lib/hancock/recipient/docusign_recipient.rb
+++ b/lib/hancock/recipient/docusign_recipient.rb
@@ -74,6 +74,7 @@ module Hancock
           :userName => recipient.name,
           :clientUserId => recipient.client_user_id
         }.to_json
+
         Hancock::Request.send_post_request(
           "/envelopes/#{envelope_identifier}/views/recipient",
           json_body

--- a/lib/hancock/request.rb
+++ b/lib/hancock/request.rb
@@ -74,7 +74,7 @@ module Hancock
     def connection
       Faraday.new do |builder|
         builder.use FaradayMiddleware::FollowRedirects, limit: 5
-        builder.use Faraday::Response::Logger
+        builder.response :logger, Hancock.logger
         builder.adapter Faraday.default_adapter
       end
     end

--- a/lib/hancock/version.rb
+++ b/lib/hancock/version.rb
@@ -1,3 +1,3 @@
 module Hancock
-  VERSION = '0.7.4'
+  VERSION = '0.7.5'
 end

--- a/spec/lib/envelope_spec.rb
+++ b/spec/lib/envelope_spec.rb
@@ -98,7 +98,7 @@ describe Hancock::Envelope do
         }.to raise_error(described_class::NotSavedYet)
       end
 
-      it 'raises a DocusignError with the returned message if not successful' do
+      it "raises an error with the returned message if not successful" do
         response = {"errorCode" => "UNEDUCATED_FELON_ERROR", "message" => "Umbrella smoothie is bad idea."}
         subject.identifier = 'smokey-heaven'
         stub_status_change('smokey-heaven', 'floosh', 'failed_status_change', 400)
@@ -316,12 +316,12 @@ describe Hancock::Envelope do
       end
 
       context 'unsuccessful send' do
-        let!(:request_stub) { stub_envelope_creation('send_envelope', 'failed_creation', 500) }
         let(:response) {
           {"errorCode" => "YOU_ARE_A_BANANA", "message" => "Bananas are not allowed to bank."}
         }
 
         it 'raises a DocusignError with the returned message if not successful' do
+          stub_envelope_creation('send_envelope', 'failed_creation', 500)
           expect {
             subject.send!
           }.to raise_error(Hancock::Request::RequestError, "500 - #{response}")

--- a/spec/lib/recipient/recreator_spec.rb
+++ b/spec/lib/recipient/recreator_spec.rb
@@ -103,19 +103,6 @@ describe Hancock::Recipient::Recreator do
         .with(:body => "{\"signers\":[{\"recipientId\":\"123-placeholder-id\"}]}")
     end
 
-    it 'retries 3 times on timeout errors' do
-      # receive delete 4 times due to 3 retries and 1 success
-      expect(docusign_recipient).to receive(:delete).exactly(4).times.and_call_original
-
-      stub_request(:delete, %r(https://demo.docusign.net/restapi/v2/accounts/123456/envelopes/.+/recipients)).to_timeout
-      begin
-        subject.recreate_with_tabs
-      rescue Timeout::Error => e
-        reload_placeholder_stub
-        subject.recreate_with_tabs
-      end
-    end
-
     it 'does not retry errors other than Timeout' do
       allow(Hancock::Recipient).to receive(:fetch_for_envelope).and_raise(Hancock::Request::RequestError.new("500 - STUFF_WENT_WRONG - BORKED!"))
       expect{ subject.recreate_with_tabs }.to raise_error(Hancock::Request::RequestError)

--- a/spec/lib/recipient_spec.rb
+++ b/spec/lib/recipient_spec.rb
@@ -269,41 +269,42 @@ describe Hancock::Recipient do
   end
 
   describe '#signing_url' do
-    before(:each) do
-      allow(subject).to receive(:access_method).and_return(:embedded)
-    end
-
     subject {
       described_class.new(
-        :envelope_identifier => 'bluh',
-        :identifier => 'squirrel')
+        :envelope_identifier => "bluh",
+        :identifier => "squirrel",
+        :client_user_id => "client-XYZ",
+        :email => "hey@example.com",
+        :name => "Heya"
+      )
     }
 
-    it 'returns a url' do
-      parsed_body = { 'url' => 'https://demo.docusign.net/linky-linky' }
+    let(:request_body) {
+      {
+        :authenticationMethod => "none",
+        :email => "hey@example.com",
+        :returnUrl => "http://example.com/fish-tacos",
+        :userName => "Heya",
+        :clientUserId => "client-XYZ"
+      }.to_json
+    }
 
-      allow_any_instance_of(Hancock::Recipient::DocusignRecipient)
-        .to receive(:signing_url)
-        .and_return(double(:parsed_response => parsed_body))
-
-      expect(subject.signing_url('redirect-us-here-afters-please'))
-        .to eq('https://demo.docusign.net/linky-linky')
+    before(:each) do
+      stub_request(:post, /\/envelopes\/bluh\/views\/recipient/)
+        .with(:body => request_body)
+        .to_return(
+          :body => '{ "url": "https://demo.docusign.net/another-linky" }',
+          :headers => { "content-type" => "application/json" }
+        )
     end
 
-    it 'allows an optional return url' do
-      parsed_body = { 'url' => 'https://demo.docusign.net/another-linky' }
-
-      expect_any_instance_of(Hancock::Recipient::DocusignRecipient)
-        .to receive(:signing_url)
-        .with('http://example.com/fish-tacos')
-        .and_return(double(:parsed_response => parsed_body))
-
-      expect(subject.signing_url('http://example.com/fish-tacos'))
-        .to eq('https://demo.docusign.net/another-linky')
+    it "returns a url" do
+      expect(subject.signing_url("http://example.com/fish-tacos"))
+        .to eq("https://demo.docusign.net/another-linky")
     end
 
-    it 'fails if the access_method is remote' do
-      allow(subject).to receive(:access_method).and_return(:remote)
+    it "fails for remote signers" do
+      allow(subject).to receive(:client_user_id).and_return(nil)
 
       expect { subject.signing_url('return-me-here-yo') }.to raise_error(
         Hancock::Recipient::SigningUrlError,


### PR DESCRIPTION
HTTParty uses Net::HTTP under the hood, which always makes a retry
when a request fails. We don’t necessarily want to retry (causing our
process to hang that much longer) so we’re switching to using Faraday
with Typhoeus under the hood.